### PR TITLE
Fts issue 1

### DIFF
--- a/src/nl/vu/cs/tcs/tds/algo/fts/network/NodeCrasher.java
+++ b/src/nl/vu/cs/tcs/tds/algo/fts/network/NodeCrasher.java
@@ -24,6 +24,9 @@ public class NodeCrasher {
         this.nnodes = nnodes;
         numCrashedNodes = Options.instance().get(Options.CRASHED_NODES);
         this.crashedNodes = new int[numCrashedNodes];
+				for (int i = 0; i < numCrashedNodes; i++) {
+					crashedNodes[i] = -1;
+				}
         this.random = new Random();
     }
     

--- a/src/nl/vu/cs/tcs/tds/algo/fts/network/NodeCrasher.java
+++ b/src/nl/vu/cs/tcs/tds/algo/fts/network/NodeCrasher.java
@@ -24,9 +24,9 @@ public class NodeCrasher {
         this.nnodes = nnodes;
         numCrashedNodes = Options.instance().get(Options.CRASHED_NODES);
         this.crashedNodes = new int[numCrashedNodes];
-				for (int i = 0; i < numCrashedNodes; i++) {
-					crashedNodes[i] = -1;
-				}
+        for (int i = 0; i < numCrashedNodes; i++) {
+            crashedNodes[i] = -1;
+        }
         this.random = new Random();
     }
     


### PR DESCRIPTION
I noticed that node 0 could not be crashed with the current selection method. The reason for it is that the array is initialized with all zeroes and the criteria for being chosen for crashing is that the node id is not yet in the array. Since the array always contains 0 to begin with it could not be chosen.

I fixed this by simply initializing the array to be all -1. Consider using a set instead of an array and simply add to the set and it has a built in contains method.